### PR TITLE
feat(AHWR-261): Only CC sent via SFD proxy route for Claim emails from ahwr-application

### DIFF
--- a/app/email/notify-send.js
+++ b/app/email/notify-send.js
@@ -19,15 +19,21 @@ const send = async (templateId, email, personalisation) => {
   // sbi and crn were added into personalisation object to get them into here without changing upstream method signatures
   // for the time being we'll pull them out here and send into SFD route where they are needed, and make sure they don't
   // go into the old route where they aren't needed
-  const { sbi, crn } = personalisation.personalisation
-  delete personalisation.personalisation.crn
-  delete personalisation.personalisation.sbi
+  // Destructure and extract `crn` and `sbi` while creating a new object without them
+  const { crn, sbi, ...filteredPersonalisation } = personalisation.personalisation
+
+  // Create a copy of the personalisation object with crn and sbi removed
+  const copyOfPersonalisation = {
+    ...personalisation,
+    personalisation: filteredPersonalisation
+  }
+
   try {
     if (sfdMessage.enabled) {
       return sendSFDEmail(
         templateId,
         email,
-        personalisation,
+        copyOfPersonalisation,
         crn,
         sbi
       )
@@ -35,7 +41,7 @@ const send = async (templateId, email, personalisation) => {
     return notifyClient.sendEmail(
       templateId,
       email,
-      personalisation
+      copyOfPersonalisation
     )
   } catch (error) {
     throw Error(error)

--- a/app/email/notify-send.js
+++ b/app/email/notify-send.js
@@ -19,10 +19,7 @@ const send = async (templateId, email, personalisation) => {
   // sbi and crn were added into personalisation object to get them into here without changing upstream method signatures
   // for the time being we'll pull them out here and send into SFD route where they are needed, and make sure they don't
   // go into the old route where they aren't needed
-  // Destructure and extract `crn` and `sbi` while creating a new object without them
   const { crn, sbi, ...filteredPersonalisation } = personalisation.personalisation
-
-  // Create a copy of the personalisation object with crn and sbi removed
   const copyOfPersonalisation = {
     ...personalisation,
     personalisation: filteredPersonalisation

--- a/app/email/sfd-client.js
+++ b/app/email/sfd-client.js
@@ -1,6 +1,6 @@
 const sendMessage = require('../messaging/send-message')
 const { sfdRequestMsgType, messageQueueConfig: { sfdMessageQueue } } = require('../config')
-const validateSFDClaim = require('../messaging/submit-sfd-schema')
+const validateSFDSchema = require('../messaging/submit-sfd-schema')
 const states = require('../messaging/states')
 
 const sendSFDEmail = async (templateId, email, emailInput, crn, sbi) => {
@@ -17,11 +17,11 @@ const sendSFDEmail = async (templateId, email, emailInput, crn, sbi) => {
     dateTime: new Date().toISOString()
   }
 
-  if (validateSFDClaim(sfdMessage)) {
+  if (validateSFDSchema(sfdMessage)) {
     return sendMessage(sfdMessage, sfdRequestMsgType, sfdMessageQueue)
   } else {
     // Check this because I am not sure why we would still send a request here. Proxy won't handle this
-    return sendMessage({ applicationState: states.failed }, sfdRequestMsgType, sfdMessageQueue, { templateId })
+    return sendMessage({ sfdMessage: states.failed }, sfdRequestMsgType, sfdMessageQueue, { templateId })
   }
 }
 

--- a/app/messaging/submit-sfd-schema.js
+++ b/app/messaging/submit-sfd-schema.js
@@ -20,14 +20,14 @@ const submitSFDSchema = joi.object({
   dateTime: joi.date().required()
 })
 
-const validateSFDClaim = (event) => {
+const validateSFDSchema = (event) => {
   const validate = submitSFDSchema.validate(event)
 
   if (validate.error) {
-    console.log('Submit claim validation error:', util.inspect(validate.error, false, null, true))
+    console.log('Submit SFD message validation error:', util.inspect(validate.error, false, null, true))
     return false
   }
   return true
 }
 
-module.exports = validateSFDClaim
+module.exports = validateSFDSchema

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ahwr-document-generator",
-  "version": "0.13.26",
+  "version": "0.13.27",
   "description": "Generate and send documents for AHWR",
   "homepage": "https://github.com/DEFRA/ffc-ahwr-document-generator",
   "main": "app/index.js",

--- a/test/unit/email/sfd-client.test.js
+++ b/test/unit/email/sfd-client.test.js
@@ -45,7 +45,7 @@ describe('sendSFDEmail', () => {
 
     expect(sfdMessageSend).toHaveBeenCalledTimes(1)
     expect(sfdMessageSend).toHaveBeenCalledWith({
-      applicationState: 'failed'
+      sfdMessage: 'failed'
     },
     'uk.gov.ffc.ahwr.sfd.request', expect.anything(), { templateId: '99ef9794-67eb-4f18-bb38-541f30f955f8' })
   })


### PR DESCRIPTION
Updated the document generator to handle a situation where CRN and SBI were being removed from an object reference during multiple calls.