### PR TITLE
feat(AHWR-471): Add mechanism to disable and enable the notify monitor

### DIFF
--- a/app/config/message-queue.js
+++ b/app/config/message-queue.js
@@ -12,7 +12,7 @@ const buildConfig = () => {
   }
 
   const schema = Joi.object({
-    applicationdDocCreationRequestQueue: {
+    applicationDocCreationRequestQueue: {
       address: Joi.string(),
       type: Joi.string(),
       ...sharedConfigSchema
@@ -34,7 +34,7 @@ const buildConfig = () => {
   }
 
   const config = {
-    applicationdDocCreationRequestQueue: {
+    applicationDocCreationRequestQueue: {
       address: process.env.APPLICATIONDOCCREATIONREQUEST_QUEUE_ADDRESS,
       type: 'queue',
       ...sharedConfig

--- a/app/config/notify.js
+++ b/app/config/notify.js
@@ -15,7 +15,7 @@ const buildConfig = () => {
   const config = {
     carbonCopyEmailAddress: process.env.CARBON_COPY_EMAIL_ADDRESS,
     notifyApiKey: process.env.NOTIFY_API_KEY,
-    notifyCheckInterval: process.env.NOTIFY_CHECK_INTERVAL || 30000,
+    notifyCheckInterval: process.env.NOTIFY_CHECK_INTERVAL || 3600000,
     templateIdFarmerApplicationGenerationNewUser: process.env.NOTIFY_TEMPLATE_ID_FARMER_APPLICATION_COMPLETE_NEW_USER,
     templateIdFarmerApplicationGenerationExistingUser: process.env.NOTIFY_TEMPLATE_ID_FARMER_APPLICATION_COMPLETE_EXISTING_USER
   }

--- a/app/data/index.js
+++ b/app/data/index.js
@@ -2,7 +2,7 @@ import { Sequelize, DataTypes } from 'sequelize'
 import { dbConfig } from '../config/db.js'
 import { buildDocumentLog } from './models/document-log.js'
 
-export default (() => {
+export const buildData = (() => {
   const sequelize = new Sequelize(dbConfig.database, dbConfig.username, dbConfig.password, dbConfig)
 
   // This needs to be done for each table we define in /models

--- a/app/email/notify-monitor.js
+++ b/app/email/notify-monitor.js
@@ -3,7 +3,9 @@ import { appConfig } from '../config/index.js'
 import { checkDeliveryStatus } from './notify-status.js'
 import { updateEmailStatus } from './update-email-status.js'
 
-let schedulerEnabled = true
+// Going to default to false as the underlying check is fundamentally broken
+// We do have the option to switch back on should we really want to
+let schedulerEnabled = false
 
 export const start = async () => {
   try {

--- a/app/email/notify-monitor.js
+++ b/app/email/notify-monitor.js
@@ -3,24 +3,39 @@ import { appConfig } from '../config/index.js'
 import { checkDeliveryStatus } from './notify-status.js'
 import { updateEmailStatus } from './update-email-status.js'
 
+let schedulerEnabled = true
+
 export const start = async () => {
   try {
-    console.log('Checking for messages')
-    const documentLogs = await checkEmailDelivered()
-    console.log('found', documentLogs.length, 'messages')
+    if (schedulerEnabled) {
+      console.log('Checking for messages')
+      const documentLogs = await checkEmailDelivered()
+      console.log('found', documentLogs.length, 'messages')
 
-    for (const documentLog of documentLogs) {
-      const emailReference = documentLog.emailReference
-      console.log(`Checking message with email reference ${emailReference}.`)
-      if (!emailReference) {
-        continue
+      for (const documentLog of documentLogs) {
+        const emailReference = documentLog.emailReference
+        if (!emailReference) {
+          continue
+        }
+        console.log(`Checking message with email reference ${emailReference}.`)
+        const status = await checkDeliveryStatus(emailReference)
+        await updateEmailStatus(documentLog, status)
       }
-      const status = await checkDeliveryStatus(emailReference)
-      updateEmailStatus(documentLog, status)
+    } else {
+      console.log('sleeping till next notify interval as scheduler is disabled')
     }
   } catch (err) {
     console.error(err.message)
   } finally {
     setTimeout(start, Number(appConfig.notifyConfig.notifyCheckInterval))
+  }
+}
+
+export const enableOrDisableSchedulerWork = (enableOrDisable) => {
+  schedulerEnabled = enableOrDisable
+  if (schedulerEnabled) {
+    console.log('Notify scheduler is enabled, will continue to check for message status from next interval')
+  } else {
+    console.log('Notify scheduler is disabled, will not check for message status until it is enabled again')
   }
 }

--- a/app/email/notify-status.js
+++ b/app/email/notify-status.js
@@ -1,6 +1,9 @@
 import { notifyClient } from './notify-client.js'
 
 export const checkDeliveryStatus = async (emailReference) => {
+  // this will throw for any status >= 300, so we should be catching 404s and handling appropriately
+  // however we have decided not to fix this now as it's been broken for 2 years and we're moving to
+  // SFD to send all messages
   const response = await notifyClient.getNotificationById(emailReference)
   return response.data?.status
 }

--- a/app/messaging/index.js
+++ b/app/messaging/index.js
@@ -2,13 +2,13 @@ import { MessageReceiver } from 'ffc-messaging'
 import { processDocumentRequest } from './process-document-request.js'
 import { appConfig } from '../config/index.js'
 
-const { applicationdDocCreationRequestQueue } = appConfig.messageQueueConfig
+const { applicationDocCreationRequestQueue } = appConfig.messageQueueConfig
 
 let documentGenerationReceiver
 
 export const startMessaging = async () => {
   const documentGenerationAction = (message) => processDocumentRequest(message, documentGenerationReceiver)
-  documentGenerationReceiver = new MessageReceiver(applicationdDocCreationRequestQueue, documentGenerationAction)
+  documentGenerationReceiver = new MessageReceiver(applicationDocCreationRequestQueue, documentGenerationAction)
   await documentGenerationReceiver.subscribe()
 
   console.info('Ready to receive messages')

--- a/app/messaging/process-document-request.js
+++ b/app/messaging/process-document-request.js
@@ -1,11 +1,16 @@
 import { generateDocument } from '../document/index.js'
 import { sendFarmerApplicationEmail } from '../email/notify-send.js'
 import { validateDocumentRequest } from './document-request-schema.js'
+import joi from 'joi'
+import { enableOrDisableSchedulerWork } from '../email/notify-monitor.js'
 
 export const processDocumentRequest = async (message, receiver) => {
   try {
     const messageBody = message.body
-    if (validateDocumentRequest(messageBody)) {
+    if (validateNotifySchedulerMessage(messageBody)) {
+      enableOrDisableSchedulerWork(messageBody.enableSchedule)
+      await receiver.completeMessage(message)
+    } else if (validateDocumentRequest(messageBody)) {
       console.log('Received document generation request', JSON.stringify(messageBody))
       const { blob } = await generateDocument(messageBody)
       await sendFarmerApplicationEmail(messageBody, blob)
@@ -15,4 +20,18 @@ export const processDocumentRequest = async (message, receiver) => {
     await receiver.deadLetterMessage(message)
     console.error('Unable to document generation request:', err.message)
   }
+}
+
+const controlNotifySchedulerSchema = joi.object({
+  enableSchedule: joi.boolean().required()
+})
+
+export const validateNotifySchedulerMessage = (event) => {
+  const { error } = controlNotifySchedulerSchema.validate(event)
+
+  if (error) {
+    return false
+  }
+  console.log(`Received a control message for notify scheduler, enableSchedule: ${event.enableSchedule}`)
+  return true
 }

--- a/app/repositories/document-log-repository.js
+++ b/app/repositories/document-log-repository.js
@@ -1,9 +1,10 @@
-import buildData from '../data/index.js'
+import { buildData } from '../data/index.js'
+import { DOCUMENT_STATUSES } from '../constants.js'
 
 const { models } = buildData
 
 export const checkEmailDelivered = async () => {
-  return models.documentLog.findAll({ where: { completed: null } })
+  return models.documentLog.findAll({ where: { completed: null, status: DOCUMENT_STATUSES.EMAIL_CREATED } })
 }
 
 export const set = async (data, fileName) => {

--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -1,7 +1,3 @@
 module.exports = {
-  env: {
-    development: {
-      plugins: ['@babel/plugin-transform-modules-commonjs']
-    }
-  }
+  plugins: ['@babel/plugin-transform-modules-commonjs']
 }

--- a/helm/ffc-ahwr-document-generator/values.yaml
+++ b/helm/ffc-ahwr-document-generator/values.yaml
@@ -30,7 +30,7 @@ deployment:
   maxReplicas: 2
   priorityClassName: default
   restartPolicy: Always
-  replicas: 2
+  replicas: 1
 
 container:
   messageQueueHost: namespace.servicebus.windows.net

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ffc-ahwr-document-generator",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ffc-ahwr-document-generator",
-      "version": "1.0.4",
+      "version": "1.1.0",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@azure/identity": "^4.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ahwr-document-generator",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Generate and send documents for AHWR",
   "homepage": "https://github.com/DEFRA/ffc-ahwr-document-generator",
   "main": "app/index.js",
@@ -15,9 +15,6 @@
     "start:debug": "nodemon --inspect-brk=0.0.0.0 --ext js --legacy-watch app/index.js"
   },
   "author": "Defra",
-  "contributors": [
-    "Satish Chatap github.com/govTechSatish"
-  ],
   "license": "OGL-UK-3.0",
   "dependencies": {
     "@azure/identity": "^4.4.1",

--- a/test/unit/email/notify-monitor.test.js
+++ b/test/unit/email/notify-monitor.test.js
@@ -24,10 +24,22 @@ describe('run notify monitor', () => {
     jest.resetAllMocks()
   })
 
-  test('check for messages and check status', async () => {
+  test('By default, do not check for messages', async () => {
     checkEmailDelivered.mockResolvedValue([{ emailReference }])
     checkDeliveryStatus.mockResolvedValue(NOTIFY_STATUSES.DELIVERED)
 
+    await start()
+
+    expect(checkDeliveryStatus).toHaveBeenCalledTimes(0)
+    expect(checkEmailDelivered).toHaveBeenCalledTimes(0)
+    expect(updateEmailStatus).toHaveBeenCalledTimes(0)
+  })
+
+  test('check for messages and check status when enableSchedule set to true', async () => {
+    checkEmailDelivered.mockResolvedValue([{ emailReference }])
+    checkDeliveryStatus.mockResolvedValue(NOTIFY_STATUSES.DELIVERED)
+
+    enableOrDisableSchedulerWork(true)
     await start()
 
     expect(checkDeliveryStatus).toHaveBeenCalledTimes(1)
@@ -35,9 +47,10 @@ describe('run notify monitor', () => {
     expect(updateEmailStatus).toHaveBeenCalledTimes(1)
   })
 
-  test('check for messages and skip null email reference', async () => {
+  test('check for messages and skip null email reference when enableSchedule set to true', async () => {
     checkEmailDelivered.mockResolvedValue([{ emailReference: null }])
 
+    enableOrDisableSchedulerWork(true)
     await start()
 
     expect(checkDeliveryStatus).toHaveBeenCalledTimes(0)

--- a/test/unit/email/notify-monitor.test.js
+++ b/test/unit/email/notify-monitor.test.js
@@ -1,8 +1,8 @@
-import { start } from '../../../app/email/notify-monitor'
+import { start, enableOrDisableSchedulerWork } from '../../../app/email/notify-monitor'
 import { NOTIFY_STATUSES } from '../../../app/constants'
 import { checkEmailDelivered } from '../../../app/repositories/document-log-repository'
 import { checkDeliveryStatus } from '../../../app/email/notify-status'
-import { updateEmailStatus } from '.../../../app/email/update-email-status'
+import { updateEmailStatus } from '../../../app/email/update-email-status'
 
 jest.mock('.../../../app/email/update-email-status')
 jest.mock('.../../../app/email/notify-status')
@@ -42,6 +42,18 @@ describe('run notify monitor', () => {
 
     expect(checkDeliveryStatus).toHaveBeenCalledTimes(0)
     expect(checkEmailDelivered).toHaveBeenCalledTimes(1)
+    expect(updateEmailStatus).toHaveBeenCalledTimes(0)
+  })
+
+  test('do not check for messages when enableSchedule is false', async () => {
+    checkEmailDelivered.mockResolvedValue([{ emailReference }])
+    checkDeliveryStatus.mockResolvedValue(NOTIFY_STATUSES.DELIVERED)
+
+    enableOrDisableSchedulerWork(false)
+    await start()
+
+    expect(checkDeliveryStatus).toHaveBeenCalledTimes(0)
+    expect(checkEmailDelivered).toHaveBeenCalledTimes(0)
     expect(updateEmailStatus).toHaveBeenCalledTimes(0)
   })
 })

--- a/test/unit/email/notify-status.test.js
+++ b/test/unit/email/notify-status.test.js
@@ -5,13 +5,17 @@ import { notifyClient } from '../../../app/email/notify-client'
 
 jest.mock('../../../app/email/notify-client')
 
-const mockGetNotificationById = jest.fn().mockResolvedValue({ data: { status: NOTIFY_STATUSES.DELIVERED } })
-notifyClient.getNotificationById = mockGetNotificationById
-
 const reference = requestedDelivery.reference
 
 describe('check delivery status', () => {
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
   test('calls notify endpoint once', async () => {
+    const mockGetNotificationById = jest.fn().mockResolvedValueOnce({ data: { status: NOTIFY_STATUSES.DELIVERED } })
+    notifyClient.getNotificationById = mockGetNotificationById
+
     const result = await checkDeliveryStatus(reference)
     expect(mockGetNotificationById).toHaveBeenCalledTimes(1)
     expect(mockGetNotificationById).toHaveBeenCalledWith(reference)

--- a/test/unit/messaging/index.test.js
+++ b/test/unit/messaging/index.test.js
@@ -20,7 +20,7 @@ jest.mock('../../../app/messaging/process-document-request', () => ({
 describe('startMessaging', () => {
   test('it instantiates the message receiver and subscribes to messages', async () => {
     await startMessaging()
-    expect(constructorSpy).toHaveBeenCalledWith(appConfig.messageQueueConfig.applicationdDocCreationRequestQueue, expect.any(Function))
+    expect(constructorSpy).toHaveBeenCalledWith(appConfig.messageQueueConfig.applicationDocCreationRequestQueue, expect.any(Function))
     expect(mockSubscribe).toHaveBeenCalled()
   })
 })

--- a/test/unit/messaging/process-document-request.test.js
+++ b/test/unit/messaging/process-document-request.test.js
@@ -1,4 +1,5 @@
 import { sendFarmerApplicationEmail } from '../../../app/email/notify-send'
+import { enableOrDisableSchedulerWork } from '../../../app/email/notify-monitor.js'
 import { validateDocumentRequest } from '../../../app/messaging/document-request-schema'
 import { mockDocumentRequest } from '../../mocks/data'
 import { processDocumentRequest } from '../../../app/messaging/process-document-request'
@@ -7,6 +8,7 @@ import { generateDocument } from '../../../app/document'
 jest.mock('ffc-messaging')
 jest.mock('../../../app/data')
 jest.mock('../../../app/email/notify-send')
+jest.mock('../../../app/email/notify-monitor')
 jest.mock('../../../app/messaging/document-request-schema')
 jest.mock('../../../app/document')
 jest.mock('../../../app/getDirName', () => ({
@@ -45,6 +47,34 @@ describe('process document request message', () => {
       body: mockDocumentRequest
     }
     await processDocumentRequest(message, receiver)
+
+    expect(validateDocumentRequest).toBeCalled()
+    expect(receiver.deadLetterMessage).toHaveBeenCalledWith(message)
+  })
+
+  test('passes enableDisable message through to notify monitor when receiving', async () => {
+    enableOrDisableSchedulerWork.mockImplementationOnce(() => {})
+    const message = {
+      body: {
+        enableSchedule: false
+      }
+    }
+    await processDocumentRequest(message, receiver)
+    expect(enableOrDisableSchedulerWork).toHaveBeenCalledWith(false)
+    expect(validateDocumentRequest).not.toHaveBeenCalled()
+    expect(receiver.completeMessage).toHaveBeenCalledWith(message)
+  })
+
+  test('failing validation on enableDisable message schema will call through to regular schema validation before failing', async () => {
+    enableOrDisableSchedulerWork.mockImplementationOnce(() => {})
+    validateDocumentRequest.mockImplementation(() => { throw new Error() })
+    const message = {
+      body: {
+        enableSchedule: 'bananas'
+      }
+    }
+    await processDocumentRequest(message, receiver)
+    expect(enableOrDisableSchedulerWork).not.toHaveBeenCalled()
     expect(receiver.deadLetterMessage).toHaveBeenCalledWith(message)
   })
 })

--- a/test/unit/repositories/document-log-repository.test.js
+++ b/test/unit/repositories/document-log-repository.test.js
@@ -16,15 +16,8 @@ jest.mock('../../../app/data/index', () => {
 })
 
 describe('Document Log repository test', () => {
-  const env = process.env
-
   afterEach(() => {
     jest.clearAllMocks()
-  })
-
-  afterEach(() => {
-    jest.resetAllMocks()
-    process.env = { ...env }
   })
 
   test('Should query for outstanding email status rows using expected query criteria', async () => {

--- a/test/unit/repositories/document-log-repository.test.js
+++ b/test/unit/repositories/document-log-repository.test.js
@@ -1,0 +1,36 @@
+import { checkEmailDelivered } from '../../../app/repositories/document-log-repository.js'
+import { buildData } from '../../../app/data/index.js'
+
+jest.mock('../../../app/data/index', () => {
+  return {
+    buildData: {
+      models: {
+        documentLog: {
+          findAll: jest.fn(),
+          create: jest.fn(),
+          update: jest.fn()
+        }
+      }
+    }
+  }
+})
+
+describe('Document Log repository test', () => {
+  const env = process.env
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+    process.env = { ...env }
+  })
+
+  test('Should query for outstanding email status rows using expected query criteria', async () => {
+    buildData.models.documentLog.findAll.mockResolvedValueOnce([])
+    await checkEmailDelivered()
+
+    expect(buildData.models.documentLog.findAll).toHaveBeenCalledWith({ where: { completed: null, status: 'email-created' } })
+  })
+})


### PR DESCRIPTION
Default to not doing the scheduled check on message status. We do however have a way to switch it on if we really want to by sending a message to the input queue with the following shape:

```
{
  "enableSchedule": true
}
```
There are a couple of config changes in here too:
- Switch to 1 replica of the service, the current 2 are processing 20 odd requests a day between them, and having 2 makes it more likely we'd see problems if the scheduled functionality was enabled
- Change the interval for checking the email status to an hour, the previous default of 30 seconds was completely unrealistic
- (code not config) but if/when the scheduled check is ever performed, we now don't consider entries in DB that haven't been set to email-created, because we'd never be able to retrieve statuses for those no matter what

I've also fixed a couple of spelling mistakes, and added test coverage for a function I changed that had no coverage at all previously..

**What is NOT fixed here (purposely):**
- When email status request is sent, any reponse code above 299 would throw an error, so to fix 'properly' we'd need to try/catch this and then gracefully handle several scenarios. We might need to mark an entry that got a 404 response as some unresolvable status so we don;t retry next time, and then handle other error responses another way to make sure they are retried. it was decided this was not worth the effort, given we're moving to SFD and this has been broken so long.